### PR TITLE
Relative Velocity Calculation Adjustment

### DIFF
--- a/Manifold.cpp
+++ b/Manifold.cpp
@@ -67,7 +67,7 @@ void Manifold::ApplyImpulse( void )
     Vec2 rb = contacts[i] - B->position;
 
     // Relative velocity
-    Vec2 rv = B->velocity + Cross( B->angularVelocity, rb ) -
+    Vec2 rv = B->velocity - Cross( B->angularVelocity, rb ) -
               A->velocity - Cross( A->angularVelocity, ra );
 
     // Relative velocity along the normal
@@ -92,7 +92,7 @@ void Manifold::ApplyImpulse( void )
     B->ApplyImpulse(  impulse, rb );
 
     // Friction impulse
-    rv = B->velocity + Cross( B->angularVelocity, rb ) -
+    rv = B->velocity - Cross( B->angularVelocity, rb ) -
          A->velocity - Cross( A->angularVelocity, ra );
 
     Vec2 t = rv - (normal * Dot( rv, normal ));


### PR DESCRIPTION
In translating this code to a VB.Net implementation, it was found that objects would build up angular velocity until they "exploded" against one another.  This is most evident if you create an open "box" of fixed colliders and then drop an assortment of polygons and circles into the box.

Thanks to assistance from this thread (https://social.msdn.microsoft.com/Forums/vstudio/en-US/65526d49-5107-4ffc-b25e-1b5a619afcb3/2d-rigidbody-physics-engine-bug?forum=vbgeneral) it was determined that the rv values should be calculated with subtraction on both terms:

"And both minus (b.vel - ... and a.vel - ...) (not both plus), because of viewing from A to B (standing on the edge of A looking at the mass-point of B moving by -> standing on earth watching a shootingstar)"

The two changes proposed in this file solved the issue and the translated code works exactly as expected now.

PS. Thanks so much for creating this and the associated articles on your blog!  Amazing, wonderful, outstanding work!!
